### PR TITLE
Value "tabs": Tab markieren bei innenliegenden Feldern mit Fehlermeldung

### DIFF
--- a/lib/yform/value/tabs.php
+++ b/lib/yform/value/tabs.php
@@ -24,6 +24,7 @@ class rex_yform_value_tabs extends rex_yform_value_abstract
     public array $tabset = [];
     public int $sequence;
     public bool $selected = false;
+    public string $hasErrorField = '';
 
     public string $fragment = 'value.tabs.tpl.php';
 
@@ -70,6 +71,18 @@ class rex_yform_value_tabs extends rex_yform_value_abstract
         $tabElements[$active]->selected = true;
         // Das letzte Element erhält die Nummer PHP_INT_MAX;
         $tabElements[array_key_last($tabElements)]->sequence = PHP_INT_MAX;
+
+        // Gibt es Fehlermeldungen in einem Tab-Bereich? Dann den Tab markieren
+        $tabKeys = array_keys($tabElements);
+        foreach ($this->params['warning'] as $needle => $errorClass) {
+            $fields = array_filter($tabKeys, static function ($v) use ($needle) {
+                return $v < $needle;
+            });
+            $errorTab = end($fields);
+            if (false !== $errorTab) {
+                $tabElements[$errorTab]->hasErrorField = $errorClass;
+            }
+        }
     }
 
     /**

--- a/ytemplates/bootstrap/value.tabs.tpl.php
+++ b/ytemplates/bootstrap/value.tabs.tpl.php
@@ -21,6 +21,7 @@
 if ('open_tabset' === $option) {
     echo '<ul class="nav nav-tabs">',PHP_EOL;
     foreach ($tabset as $tab) {
+        if (PHP_INT_MAX !== $tab->sequence) {
             $tabLabel = $tab->getLabel();
             $tabHTMLid = $tab->getHTMLId();
             $class = [];

--- a/ytemplates/bootstrap/value.tabs.tpl.php
+++ b/ytemplates/bootstrap/value.tabs.tpl.php
@@ -21,11 +21,18 @@
 if ('open_tabset' === $option) {
     echo '<ul class="nav nav-tabs">',PHP_EOL;
     foreach ($tabset as $tab) {
-        if (PHP_INT_MAX !== $tab->sequence) {
             $tabLabel = $tab->getLabel();
             $tabHTMLid = $tab->getHTMLId();
-            $isActive = $tab->selected ? ' class="active"' : '';
-            echo '  <li role="presentation"',$isActive,'><a data-toggle="tab" href="#',$tabHTMLid,'">',$tabLabel,'</a></li>',PHP_EOL;
+            $class = [];
+            if ($tab->selected) {
+                $class[] = 'active';
+            }
+            if ($tab->hasErrorField) {
+                $class[] = $tab->hasErrorField;
+                $tabLabel = '<span class="text-danger"><i class="fa fa-warning"></i> ' . $tabLabel . '</span>';
+            }
+            $class = $class ? ' class="'.implode(' ', $class).'"' : '';
+            echo '  <li role="presentation"',$class,'><a data-toggle="tab" href="#',$tabHTMLid,'">',$tabLabel,'</a></li>',PHP_EOL;
         }
     }
     echo '</ul>',PHP_EOL;


### PR DESCRIPTION
Haben Felder eine Fehlermeldung aus YForm-Validierung (`$this->params['warning'][$feldindex] = 'has-error'`) und liegt das Feld innerhalb eines Tabs, wird der Tab-Titel als Warnung markiert
- `$tabLabel = '<span class="text-danger"><i class="fa fa-warning"></i> ' . $tabLabel . '</span>';`
- Die Klasse (hier `'has-error'`) wird dem `<li>`-Tag hinzugefügt, was aber ohne entsprechendes HTML erst einmal keine Auswirkungen hat.

<img width="875" alt="grafik" src="https://user-images.githubusercontent.com/10065904/212272568-1b59a337-16bb-431d-a3c9-f786ee3398ed.png">

Dazu braucht es kein zusätzliches CSS, läuft alles mit dem integrierten Bootstrap 