### PR TITLE
SCSS-Support initial wg. (S)CSS für Value "tabs"

### DIFF
--- a/assets/be.min.css
+++ b/assets/be.min.css
@@ -1,0 +1,1 @@
+.yform .tab-content{background-color:transparent}.yform .tab-content .tab-pane{margin:6px 12px}

--- a/boot.php
+++ b/boot.php
@@ -3,3 +3,7 @@
 rex_extension::register('PACKAGES_INCLUDED', function (rex_extension_point $ep) {
     rex_yform::addTemplatePath($this->getPath('ytemplates'));
 });
+
+if (rex::isBackend()) {
+    rex_view::addCssFile($this->getAssetsUrl('be.min.css'));
+}

--- a/install.php
+++ b/install.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @var rex_addon $this
+ */
+
+/**
+ * Erstellt eine CSS-Datei basierend auf den Backend-Styles aus dem Addon be_style (falls aktiv).
+ * rex_scss_compiler ist verfügbar wenn be_style installiert ist.
+ */
+if (class_exists('rex_scss_compiler')) {
+    $compiler = new rex_scss_compiler();
+
+    if( rex::isDebugMode() || false === $this->getProperty('compress_assets',true)) {
+        // Klartext-Ausgabe falls man für Tests "lesbares" CSS erzeugen möchte
+        $compiler->setFormatter(\ScssPhp\ScssPhp\Formatter\Expanded::class);
+    }
+
+    $compiler->setRootDir(__DIR__ . '/scss');
+    $compiler->setScssFile([
+        rex_path::plugin('be_style', 'redaxo', 'scss/_variables.scss'),
+        rex_path::plugin('be_style', 'redaxo', 'scss/_variables-dark.scss'),
+        rex_path::addon('be_style', 'vendor/font-awesome/scss/_variables.scss'),
+        __DIR__ . '/scss/be.scss',
+    ]);
+
+    $compiler->setCssFile(__DIR__ . '/assets/be.min.css');
+    $compiler->compile();
+}

--- a/install.php
+++ b/install.php
@@ -11,9 +11,9 @@
 if (class_exists('rex_scss_compiler')) {
     $compiler = new rex_scss_compiler();
 
-    if( rex::isDebugMode() || false === $this->getProperty('compress_assets',true)) {
+    if( !rex::isDebugMode() && false !== $this->getProperty('compress_assets',true)) {
         // Klartext-Ausgabe falls man für Tests "lesbares" CSS erzeugen möchte
-        $compiler->setFormatter(\ScssPhp\ScssPhp\Formatter\Expanded::class);
+        $compiler->setOutputStyle(\ScssPhp\ScssPhp\OutputStyle::COMPRESSED);
     }
 
     $compiler->setRootDir(__DIR__ . '/scss');

--- a/scss/be.scss
+++ b/scss/be.scss
@@ -1,0 +1,11 @@
+/**
+ * rey_yform_value_tabs
+ *  - Hintergrund transparent, damit die Felder "wie immer" aussehen (weiß auf hellgrün)
+ *  - Felder im Tab etwas einrücken, damit der Rahmen, der den Tabset umschließt, zur Geltung kommt
+ */
+ .yform .tab-content {
+    background-color: transparent;
+}
+.yform .tab-content .tab-pane {
+    margin: $padding-base-vertical $padding-base-horizontal; /* 6px 12px */
+}

--- a/update.php
+++ b/update.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * @var rex_addon $this
+ */
+ 
+$this->includeFile('install.php');


### PR DESCRIPTION
Ziel: `rex_yform_value_tabs` soll abweichend vom REDAXO/Bootstrap-Standard den Tab-Container im YForm-Formular etwas schicker anzeigen:

- Die Felder im Container sind eingerückt (Container-Padding) mit den Standard-Werten für Redaxo.
- Die Hintergrung-Farbe ist von weiß auf transparent geändert, damit der übliche YForm-Formularhintergrund zieht. Der Tab-Block ist eh durch den Rahmen kenntlich. 

Damit die (aktuellen) Padding-Werte aus REDAXO/Bootstrap gezogen werden, müssen die CSS-Einstellungen kompiliert werden. Der nötige Compiler ist in `install.php` (neu) bereitgestellt. Das bedingt zugleich eine `update.php`, die beim Update auf `install.php` weiterleitet.

Der Compiler liefert komprimiertes CSS, außer 
- debug-Mode ist aktiviert oder 
- in der `package.yml` steht eine Zeile `compress_assets: false` 

Die Quelldatei ist in `scss/be.scss` zu finden.

In der `boot.php` wird entsprechend im BE `be.min.css` geladen.
(ich hab das jetzt nur für BE gemacht, weil das Template ja Bootstrap-HTML-erzeugt) 

<img width="891" alt="grafik" src="https://user-images.githubusercontent.com/10065904/212282275-89f04fab-371c-47a5-ad69-a7d5cb29c809.png">
