### PR TITLE
Unzulässige Überschneidung zwischen Tab-Gruppen erkennen

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -12,4 +12,4 @@ yform_values_tabs_cluster_label = Tab-Gruppe
 yform_values_tabs_active_label = Aktiver Tab
 yform_values_tabs_active_notice = 'Aktiv' hat Vorrang vor 'Dynamisch'. Bei mehreren aktiven Tabs wird der erste genommen.
 yform_values_tabs_active_options = Der erste Tab der Gruppe wid aktiviert=1,Dieser Tab wird aktiviert=2
-
+yform_values_tabs_setup_prio_error = {0}: Überscheidung mit Tab-Gruppe «{1}» bei Feld «{2} [{3}]»!


### PR DESCRIPTION
Ansatz ist direkt im Tablemanager bei der Dialogerfassung der Formulare. Per Custom-Validator wird erkannt, ob gemäß Prio-Auswahl ("Priorität") das aktuell bearbeitete Tab-Feld in eine fremde Gruppe geraten ist. Bei PHP-Formularen muss man halt weiter aufpassen (wie bei deren Parametern auch).

<img width="961" alt="grafik" src="https://user-images.githubusercontent.com/10065904/212357346-913c9873-22f8-4886-b509-81031af41e8c.png">
