### PR TITLE
class::$sequence nun initialisiert

### DIFF
--- a/lib/yform/value/tabs.php
+++ b/lib/yform/value/tabs.php
@@ -22,7 +22,7 @@ class rex_yform_value_tabs extends rex_yform_value_abstract
      * @var self[] $tabset
      */
     public array $tabset = [];
-    public int $sequence;
+    public int $sequence = -1;
     public bool $selected = false;
     public string $hasErrorField = '';
 
@@ -118,6 +118,8 @@ class rex_yform_value_tabs extends rex_yform_value_abstract
         if (PHP_INT_MAX === $this->sequence) {
             $output .= $this->parse($this->fragment, ['option' => 'close_tabset']);
         }
+
+        // wenn (-1 === $this->sequence) => nix tun
 
         $this->params['form_output'][$this->getId()] = $output;
     }


### PR DESCRIPTION
Bei zu kleinen Tabsets, die nicht sinnvoll anzeigbar sind, wurde die die Initialisierung frühzeitg abgebrochen. Das führte zu Ausgabefehlern:

![grafik](https://user-images.githubusercontent.com/10065904/212365774-1e885a88-3469-418f-b5b7-5e7058b0f0d7.png)

Der PR behebt das.
