### PR TITLE
Legacy-Values radio, radio_sql, select, select_sql aus YForm 3.x

### DIFF
--- a/lib/yform/value/radio.php
+++ b/lib/yform/value/radio.php
@@ -119,8 +119,4 @@ class rex_yform_value_radio extends rex_yform_value_abstract
         }
     }
 
-    public function isDeprecated()
-    {
-        return true;
-    }
 }

--- a/lib/yform/value/radio.php
+++ b/lib/yform/value/radio.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * yform.
+ *
+ * @author jan.kristinus[at]redaxo[dot]org Jan Kristinus
+ * @author <a href="http://www.yakamara.de">www.yakamara.de</a>
+ */
+
+class rex_yform_value_radio extends rex_yform_value_abstract
+{
+    public function enterObject()
+    {
+        $options = $this->getArrayFromString($this->getElement('options'));
+
+        if (!array_key_exists($this->getValue(), $options)) {
+            $this->setValue('');
+            $default = $this->getElement('default');
+            if ($default && array_key_exists($default, $options)) {
+                $this->setValue($default);
+            }
+        }
+
+        if ($this->needsOutput()) {
+            $this->params['form_output'][$this->getId()] = $this->parse('value.radio.tpl.php', compact('options'));
+        }
+
+        $this->params['value_pool']['email'][$this->getName()] = $this->getValue();
+        if ($this->saveInDb()) {
+            $this->params['value_pool']['sql'][$this->getName()] = $this->getValue();
+        }
+    }
+
+    public function getDescription() :string
+    {
+        return 'radio|name|label|Frau=w,Herr=m|[defaultwert]|[attributes]|[notice]|[no_db]';
+    }
+
+    public function getDefinitions() :array
+    {
+        return [
+            'type' => 'value',
+            'name' => 'radio',
+            'values' => [
+                'name' => ['type' => 'name',   'label' => rex_i18n::msg('yform_values_defaults_name')],
+                'label' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_label')],
+                'options' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_radio_options')],
+                'default' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_radio_default')],
+                'attributes' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_defaults_attributes'), 'notice' => rex_i18n::msg('yform_values_defaults_attributes_notice')],
+                'notice' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_notice')],
+                'no_db' => ['type' => 'no_db',   'label' => rex_i18n::msg('yform_values_defaults_table'),          'default' => 0],
+            ],
+            'description' => rex_i18n::msg('yform_values_radio_description'),
+            'db_type' => ['int', 'text'],
+        ];
+    }
+
+    public static function getListValue($params)
+    {
+        $return = [];
+
+        $new_select = new self();
+        $values = $new_select->getArrayFromString($params['params']['field']['options']);
+
+        foreach (explode(',', $params['value']) as $k) {
+            if (isset($values[$k])) {
+                $return[] = rex_i18n::translate($values[$k]);
+            }
+        }
+
+        return implode('<br />', $return);
+    }
+
+    public static function getSearchField($params)
+    {
+        $options = [];
+        $options['(empty)'] = '(empty)';
+        $options['!(empty)'] = '!(empty)';
+
+        $new_select = new self();
+        $options += $new_select->getArrayFromString($params['field']['options']);
+
+        $params['searchForm']->setValueField(
+            'select',
+            [
+            'name' => $params['field']->getName(),
+            'label' => $params['field']->getLabel(),
+            'options' => $options,
+            'multiple' => 1,
+            'size' => 5,
+        ]
+        );
+    }
+
+    public static function getSearchFilter($params)
+    {
+        $sql = rex_sql::factory();
+
+        $field = $params['field']->getName();
+        $values = (array) $params['value'];
+
+        $where = [];
+        foreach ($values as $value) {
+            switch ($value) {
+                case '(empty)':
+                    $where[] = ' ' . $sql->escapeIdentifier($field) . ' = ""';
+                    break;
+                case '!(empty)':
+                    $where[] = ' ' . $sql->escapeIdentifier($field) . ' != ""';
+                    break;
+                default:
+                    $where[] = ' ( FIND_IN_SET( ' . $sql->escape($value) . ', ' . $sql->escapeIdentifier($field) . ') )';
+                    break;
+            }
+        }
+
+        if (count($where) > 0) {
+            return ' ( ' . implode(' or ', $where) . ' )';
+        }
+    }
+
+    public function isDeprecated()
+    {
+        return true;
+    }
+}

--- a/lib/yform/value/radio_sql.php
+++ b/lib/yform/value/radio_sql.php
@@ -46,7 +46,7 @@ class rex_yform_value_radio_sql extends rex_yform_value_abstract
         }
     }
 
-    public function getDescription()
+    public function getDescription():string
     {
         return 'radio_sql|name|label|select id,name from table order by name|[defaultvalue]|';
     }
@@ -71,7 +71,7 @@ class rex_yform_value_radio_sql extends rex_yform_value_abstract
         ];
     }
 
-    public static function getListValue($params) :string
+    public static function getListValue($params)
     {
         $return = [];
 

--- a/lib/yform/value/radio_sql.php
+++ b/lib/yform/value/radio_sql.php
@@ -161,9 +161,4 @@ class rex_yform_value_radio_sql extends rex_yform_value_abstract
             return ' ( ' . implode(' or ', $where) . ' )';
         }
     }
-
-    public function isDeprecated()
-    {
-        return true;
-    }
 }

--- a/lib/yform/value/radio_sql.php
+++ b/lib/yform/value/radio_sql.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * yform.
+ *
+ * @author jan.kristinus[at]redaxo[dot]org Jan Kristinus
+ * @author <a href="http://www.yakamara.de">www.yakamara.de</a>
+ */
+
+class rex_yform_value_radio_sql extends rex_yform_value_abstract
+{
+    public function enterObject()
+    {
+        $sql = $this->getElement('query');
+
+        $options_sql = rex_sql::factory();
+        $options_sql->setDebug($this->params['debug']);
+
+        $options = [];
+
+        try {
+            foreach ($options_sql->getArray($sql) as $t) {
+                $v = $t['name'];
+                $k = $t['id'];
+                $options[$k] = $v;
+            }
+        } catch (rex_sql_exception $e) {
+            dump($e);
+        }
+
+        if (!array_key_exists($this->getValue(), $options)) {
+            $this->setValue('');
+            $default = $this->getElement('default');
+            if ($default && array_key_exists($default, $options)) {
+                $this->setValue($default);
+            }
+        }
+
+        if ($this->needsOutput()) {
+            $this->params['form_output'][$this->getId()] = $this->parse('value.radio.tpl.php', compact('options'));
+        }
+
+        $this->params['value_pool']['email'][$this->getName()] = $this->getValue();
+        if ($this->saveInDb()) {
+            $this->params['value_pool']['sql'][$this->getName()] = $this->getValue();
+        }
+    }
+
+    public function getDescription()
+    {
+        return 'radio_sql|name|label|select id,name from table order by name|[defaultvalue]|';
+    }
+
+    public function getDefinitions() :array
+    {
+        return [
+            'type' => 'value',
+            'name' => 'radio_sql',
+            'values' => [
+                'name' => ['type' => 'name', 'label' => rex_i18n::msg('yform_values_defaults_name')],
+                'label' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_defaults_label')],
+                'query' => ['type' => 'text', 'label' => 'Query mit "select id, name from .."'],
+                'default' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_radio_default')],
+                'attributes' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_defaults_attributes'), 'notice' => rex_i18n::msg('yform_values_defaults_attributes_notice')],
+                'notice' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_defaults_notice')],
+                'no_db' => ['type' => 'no_db', 'label' => rex_i18n::msg('yform_values_defaults_table'), 'default' => 0],
+            ],
+            'description' => 'Hiermit kann man SQL Abfragen als Radioliste nutzen',
+            'db_type' => ['int', 'text'],
+            'deprecated' => rex_i18n::msg('yform_values_deprecated_radio_sql'),
+        ];
+    }
+
+    public static function getListValue($params) :string
+    {
+        $return = [];
+
+        $query = $params['params']['field']['query'];
+        $query_params = [];
+        $pos = mb_strrpos(mb_strtoupper($query), 'ORDER BY ');
+        if ($pos !== false) {
+            $query = mb_substr($query, 0, $pos);
+        }
+
+        $pos = mb_strrpos(mb_strtoupper($query), 'LIMIT ');
+        if ($pos !== false) {
+            $query = mb_substr($query, 0, $pos);
+        }
+
+        $where = ' `id` = ?';
+        $query_params[] = $params['value'];
+
+        $pos = mb_strrpos(mb_strtoupper($query), 'WHERE ');
+        if ($pos !== false) {
+            $query = mb_substr($query, 0, $pos) . ' WHERE ' . $where . ' AND ' . mb_substr($query, $pos + mb_strlen('WHERE '));
+        } else {
+            $query .= ' WHERE ' . $where;
+        }
+
+        $db = rex_sql::factory();
+        $db_array = $db->getArray($query, $query_params);
+
+        foreach ($db_array as $entry) {
+            $return[] = $entry['name'];
+        }
+
+        if (count($return) == 0 && $params['value'] != '' && $params['value'] != '0') {
+            $return[] = $params['value'];
+        }
+
+        return implode('<br />', $return);
+    }
+
+    public static function getSearchField($params)
+    {
+        $options = [];
+        $options['(empty)'] = '(empty)';
+        $options['!(empty)'] = '!(empty)';
+
+        $options_sql = rex_sql::factory();
+        $options_sql->setQuery($params['field']['query']);
+
+        foreach ($options_sql->getArray() as $t) {
+            $options[$t['id']] = $t['name'];
+        }
+
+        $params['searchForm']->setValueField(
+            'select',
+            [
+            'name' => $params['field']->getName(),
+            'label' => $params['field']->getLabel(),
+            'options' => $options,
+            'multiple' => 1,
+            'size' => 5,
+        ]
+        );
+    }
+
+    public static function getSearchFilter($params)
+    {
+        $sql = rex_sql::factory();
+        $field = $params['field']->getName();
+        $values = (array) $params['value'];
+
+        $where = [];
+        foreach ($values as $value) {
+            switch ($value) {
+                case '(empty)':
+                    $where[] = $sql->escapeIdentifier($field).' = ""';
+                    break;
+                case '!(empty)':
+                    $where[] = $sql->escapeIdentifier($field).' != ""';
+                    break;
+                default:
+                    $where[] = ' ( FIND_IN_SET( ' . $sql->escape($value) . ', ' . $sql->escapeIdentifier($field) . ') )';
+                    break;
+            }
+        }
+
+        if (count($where) > 0) {
+            return ' ( ' . implode(' or ', $where) . ' )';
+        }
+    }
+
+    public function isDeprecated()
+    {
+        return true;
+    }
+}

--- a/lib/yform/value/select.php
+++ b/lib/yform/value/select.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * yform.
+ *
+ * @author jan.kristinus[at]redaxo[dot]org Jan Kristinus
+ * @author <a href="http://www.yakamara.de">www.yakamara.de</a>
+ */
+
+class rex_yform_value_select extends rex_yform_value_abstract
+{
+    public function enterObject()
+    {
+        $multiple = $this->getElement('multiple') == 1;
+        $options = $this->getArrayFromString($this->getElement('options'));
+
+        if ($multiple) {
+            $size = (int) $this->getElement('size');
+            if ($size < 2) {
+                $size = count($options);
+            }
+
+            $values = $this->getValue();
+            if (!is_array($values)) {
+                $values = explode(',', $values);
+            }
+
+            $real_values = [];
+            foreach ($values as $value) {
+                if (isset($options[$value])) {
+                    $real_values[] = $value;
+                }
+            }
+
+            $this->setValue($real_values);
+        } else {
+            $size = 1;
+            $default = null;
+
+            if (isset($options[$this->getElement('default')])) {
+                $default = $this->getElement('default');
+            }
+            $value = (string) $this->getValue();
+
+            if (!isset($options[$value])) {
+                if ($default !== null) {
+                    $this->setValue([$default]);
+                } else {
+                    reset($options);
+                    $this->setValue([key($options)]);
+                }
+            } else {
+                $this->setValue([$value]);
+            }
+        }
+
+        // ---------- rex_yform_set
+        if (isset($this->params['rex_yform_set'][$this->getName()]) && !is_array($this->params['rex_yform_set'][$this->getName()])) {
+            $value = $this->params['rex_yform_set'][$this->getName()];
+            $values = [];
+            if (array_key_exists($value, $options)) {
+                $values[] = (string) $value;
+            }
+            $this->setValue($values);
+            $this->setElement('disabled', true);
+        }
+
+        if ($this->needsOutput()) {
+            $this->params['form_output'][$this->getId()] = $this->parse('value.select.tpl.php', compact('options', 'multiple', 'size'));
+        }
+
+        $this->setValue(implode(',', $this->getValue()));
+
+        $this->params['value_pool']['email'][$this->getName()] = $this->getValue();
+        $this->params['value_pool']['email'][$this->getName() . '_NAME'] = isset($options[$this->getValue()]) ? $options[$this->getValue()] : null;
+
+        if ($this->saveInDb()) {
+            $this->params['value_pool']['sql'][$this->getName()] = $this->getValue();
+        }
+    }
+
+    public function getDescription() :string
+    {
+        return 'select|name|label|Frau=w,Herr=m|[no_db]|defaultwert|multiple=1|selectsize';
+    }
+
+    public function getDefinitions() :array
+    {
+        return [
+            'type' => 'value',
+            'name' => 'select',
+            'values' => [
+                'name' => ['type' => 'name',   'label' => rex_i18n::msg('yform_values_defaults_name')],
+                'label' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_label')],
+                'options' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_select_options')],
+                'no_db' => ['type' => 'no_db',   'label' => rex_i18n::msg('yform_values_defaults_table'),          'default' => 0],
+                'default' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_select_default')],
+                'multiple' => ['type' => 'boolean', 'label' => rex_i18n::msg('yform_values_select_multiple')],
+                'size' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_select_size')],
+                'attributes' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_attributes'), 'notice' => rex_i18n::msg('yform_values_defaults_attributes_notice')],
+                'notice' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_notice')],
+            ],
+            'description' => rex_i18n::msg('yform_values_select_description'),
+            'db_type' => ['int', 'text'],
+        ];
+    }
+
+    public static function getListValue($params)
+    {
+        $return = [];
+
+        $new_select = new self();
+        $values = $new_select->getArrayFromString($params['params']['field']['options']);
+
+        foreach (explode(',', $params['value']) as $k) {
+            if (isset($values[$k])) {
+                $return[] = rex_i18n::translate($values[$k]);
+            }
+        }
+
+        return implode('<br />', $return);
+    }
+
+    public static function getSearchField($params)
+    {
+        $options = [];
+        $options['(empty)'] = '(empty)';
+        $options['!(empty)'] = '!(empty)';
+
+        $new_select = new self();
+        $options += $new_select->getArrayFromString($params['field']['options']);
+
+        if (isset($options[''])) {
+            unset($options['']);
+        }
+
+        $params['searchForm']->setValueField(
+            'select',
+            [
+            'name' => $params['field']->getName(),
+            'label' => $params['field']->getLabel(),
+            'options' => $options,
+            'multiple' => 1,
+            'size' => 5,
+            'notice' => rex_i18n::msg('yform_search_defaults_select_notice'),
+        ]
+        );
+    }
+
+    public static function getSearchFilter($params)
+    {
+        $sql = rex_sql::factory();
+
+        $field = $params['field']->getName();
+
+        $self = new self();
+        $values = $self->getArrayFromString($params['value']);
+
+        $multiple = $params['field']->getElement('multiple') == 1;
+
+        $where = [];
+        foreach ($values as $value) {
+            switch ($value) {
+                case '(empty)':
+                    $where[] = ' ' . $sql->escapeIdentifier($field) . ' = ""';
+                    break;
+                case '!(empty)':
+                    $where[] = ' ' . $sql->escapeIdentifier($field) . ' != ""';
+                    break;
+                default:
+                    if ($multiple) {
+                        $where[] = ' ( FIND_IN_SET( ' . $sql->escape($value) . ', ' . $sql->escapeIdentifier($field) . ') )';
+                    } else {
+                        $where[] = ' ( ' . $sql->escape($value) . ' = ' . $sql->escapeIdentifier($field) . ' )';
+                    }
+
+                    break;
+            }
+        }
+
+        if (count($where) > 0) {
+            return ' ( ' . implode(' or ', $where) . ' )';
+        }
+    }
+
+    public function isDeprecated()
+    {
+        return true;
+    }
+}

--- a/lib/yform/value/select.php
+++ b/lib/yform/value/select.php
@@ -182,9 +182,4 @@ class rex_yform_value_select extends rex_yform_value_abstract
             return ' ( ' . implode(' or ', $where) . ' )';
         }
     }
-
-    public function isDeprecated()
-    {
-        return true;
-    }
 }

--- a/lib/yform/value/select_sql.php
+++ b/lib/yform/value/select_sql.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * yform.
+ *
+ * @author jan.kristinus[at]redaxo[dot]org Jan Kristinus
+ * @author <a href="http://www.yakamara.de">www.yakamara.de</a>
+ */
+
+class rex_yform_value_select_sql extends rex_yform_value_abstract
+{
+    public static $getListValues = [];
+
+    public function enterObject()
+    {
+        $multiple = $this->getElement('multiple') == 1;
+
+        $sql = $this->getElement('query');
+
+        $options_sql = rex_sql::factory();
+        $options_sql->setDebug($this->params['debug']);
+
+        $options = [];
+
+        try {
+            foreach ($options_sql->getArray($sql) as $t) {
+                $options[$t['id']] = $t['name'];
+            }
+        } catch (rex_sql_exception $e) {
+            dump($e);
+        }
+
+        if ($multiple) {
+            $size = (int) $this->getElement('size');
+            if ($size < 2) {
+                $size = count($options);
+            }
+
+            $values = $this->getValue();
+            if (!is_array($values)) {
+                $values = explode(',', $values);
+            }
+
+            $real_values = [];
+            foreach ($values as $value) {
+                if (array_key_exists($value, $options)) {
+                    $real_values[] = $value;
+                }
+            }
+
+            $this->setValue($real_values);
+        } else {
+            $size = 1;
+
+            if ($this->getElement('empty_option') == 1) {
+                $options = ['0' => (string) $this->getElement('empty_value')] + $options;
+            }
+
+            $default = null;
+            if (array_key_exists((string) $this->getElement('default'), $options)) {
+                $default = $this->getElement('default');
+            }
+            $value = (string) $this->getValue();
+
+            if (!array_key_exists($value, $options)) {
+                if ($default || $default === '0') {
+                    $this->setValue([$default]);
+                } else {
+                    reset($options);
+                    $this->setValue([key($options)]);
+                }
+            } else {
+                $this->setValue([$value]);
+            }
+        }
+
+        // ---------- rex_yform_set
+        if (isset($this->params['rex_yform_set'][$this->getName()]) && !is_array($this->params['rex_yform_set'][$this->getName()])) {
+            $value = $this->params['rex_yform_set'][$this->getName()];
+            $values = [];
+            if (array_key_exists($value, $options)) {
+                $values[] = $value;
+            }
+            $this->setValue($values);
+            $this->setElement('disabled', true);
+        }
+        // ----------
+
+        if ($this->needsOutput()) {
+            $this->params['form_output'][$this->getId()] = $this->parse('value.select.tpl.php', compact('options', 'multiple', 'size'));
+        }
+
+        $this->setValue(implode(',', $this->getValue()));
+
+        $this->params['value_pool']['email'][$this->getName()] = $this->getValue();
+        $this->params['value_pool']['email'][$this->getName() . '_NAME'] = isset($options[$this->getValue()]) ? $options[$this->getValue()] : null;
+
+        if ($this->saveInDb()) {
+            $this->params['value_pool']['sql'][$this->getName()] = $this->getValue();
+        }
+    }
+
+    public function getDescription() :string
+    {
+        return 'select_sql|name|label| select id,name from table order by name | [defaultvalue] | [no_db] |1/0 Leeroption|Leeroptionstext|1/0 Multiple Feld|selectsize';
+    }
+
+    public function getDefinitions() :array
+    {
+        return [
+            'type' => 'value',
+            'name' => 'select_sql',
+            'values' => [
+                'name' => ['type' => 'name',    'label' => rex_i18n::msg('yform_values_defaults_name')],
+                'label' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_label')],
+                'query' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_select_sql_query')],
+                'default' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_select_sql_default')],
+                'no_db' => ['type' => 'no_db',   'label' => rex_i18n::msg('yform_values_defaults_table'),  'default' => 0],
+                'empty_option' => ['type' => 'boolean', 'label' => rex_i18n::msg('yform_values_select_sql_empty_option')],
+                'empty_value' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_select_sql_empty_value')],
+                'multiple' => ['type' => 'boolean', 'label' => rex_i18n::msg('yform_values_select_sql_multiple')],
+                'size' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_select_sql_size')],
+                'attributes' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_attributes'), 'notice' => rex_i18n::msg('yform_values_defaults_attributes_notice')],
+                'notice' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_notice')],
+            ],
+            'description' => rex_i18n::msg('yform_values_select_sql_description'),
+            'db_type' => ['int', 'text'],
+        ];
+    }
+
+    public static function getListValue($params)
+    {
+        $return = [];
+
+        $query = $params['params']['field']['query'];
+        $query_params = [];
+        $pos = mb_strrpos(mb_strtoupper($query), 'ORDER BY ');
+        if ($pos !== false) {
+            $query = mb_substr($query, 0, $pos);
+        }
+
+        $pos = mb_strrpos(mb_strtoupper($query), 'LIMIT ');
+        if ($pos !== false) {
+            $query = mb_substr($query, 0, $pos);
+        }
+
+        $multiple = (isset($params['params']['field']['multiple'])) ? (int) $params['params']['field']['multiple'] : 0;
+        if ($multiple != 1) {
+            $where = ' `id` = ?';
+            $query_params[] = $params['value'];
+        } else {
+            $where = ' FIND_IN_SET(`id`, ?)';
+            $query_params[] = $params['value'];
+        }
+
+        $pos = mb_strrpos(mb_strtoupper($query), 'WHERE ');
+        if ($pos !== false) {
+            $query = mb_substr($query, 0, $pos) . ' WHERE ' . $where . ' AND ' . mb_substr($query, $pos + strlen('WHERE '));
+        } else {
+            $query .= ' WHERE ' . $where;
+        }
+
+        $db = rex_sql::factory();
+        $db_array = $db->getArray($query, $query_params);
+
+        foreach ($db_array as $entry) {
+            $return[] = $entry['name'];
+        }
+
+        if (count($return) == 0 && $params['value'] != '' && $params['value'] != '0') {
+            $return[] = $params['value'];
+        }
+
+        return implode('<br />', $return);
+    }
+
+    public static function getSearchField($params)
+    {
+        $options = [];
+        $options['(empty)'] = '(empty)';
+        $options['!(empty)'] = '!(empty)';
+
+        $options_sql = rex_sql::factory();
+        $options_sql->setQuery($params['field']['query']);
+
+        foreach ($options_sql->getArray() as $t) {
+            $options[$t['id']] = $t['name'];
+        }
+
+        $params['searchForm']->setValueField(
+            'select',
+            [
+            'name' => $params['field']->getName(),
+            'label' => $params['field']->getLabel(),
+            'options' => $options,
+            'multiple' => 1,
+            'size' => 5,
+            'notice' => rex_i18n::msg('yform_search_defaults_select_notice'),
+        ]
+        );
+    }
+
+    public static function getSearchFilter($params)
+    {
+        $sql = rex_sql::factory();
+        $field = $params['field']->getName();
+        $values = (array) $params['value'];
+
+        $multiple = $params['field']->getElement('multiple') == 1;
+
+        $where = [];
+        foreach ($values as $value) {
+            switch ($value) {
+                case '(empty)':
+                    $where[] = $sql->escapeIdentifier($field).' = ""';
+                    break;
+                case '!(empty)':
+                    $where[] = $sql->escapeIdentifier($field).' != ""';
+                    break;
+                default:
+                    if ($multiple) {
+                        $where[] = ' ( FIND_IN_SET( ' . $sql->escape($value) . ', ' . $sql->escapeIdentifier($field) . ') )';
+                    } else {
+                        $where[] = ' ( ' . $sql->escape($value) . ' = ' . $sql->escapeIdentifier($field) . ' )';
+                    }
+                    break;
+            }
+        }
+
+        if (count($where) > 0) {
+            return ' ( ' . implode(' or ', $where) . ' )';
+        }
+    }
+
+    public function isDeprecated()
+    {
+        return true;
+    }
+}

--- a/lib/yform/value/select_sql.php
+++ b/lib/yform/value/select_sql.php
@@ -232,8 +232,4 @@ class rex_yform_value_select_sql extends rex_yform_value_abstract
         }
     }
 
-    public function isDeprecated()
-    {
-        return true;
-    }
 }

--- a/package.yml
+++ b/package.yml
@@ -1,14 +1,14 @@
 package: yform_field
-version: '2.2.3'
+version: '2.3.0'
 author: 'Alexander Walther'
 supportpage: https://github.com/alexplusde/yform_field
 
 requires:
-    redaxo: ^5.13
-    yform: '^4'
+    redaxo: ^5.15
+    yform: '^4.1'
     media_manager: '2.12.1'
     php:
-        version: ">=7.4,<9"
+        version: ">=8.1,<9"
         extensions: [intl]
 
 

--- a/ytemplates/bootstrap/value.radio.tpl.php
+++ b/ytemplates/bootstrap/value.radio.tpl.php
@@ -1,0 +1,55 @@
+<?php
+
+$notices = [];
+if ($this->getElement('notice') != '') {
+    $notices[] = rex_i18n::translate($this->getElement('notice'), false);
+}
+if (isset($this->params['warning_messages'][$this->getId()]) && !$this->params['hide_field_warning_messages']) {
+    $notices[] = '<span class="text-warning">' . rex_i18n::translate($this->params['warning_messages'][$this->getId()], false) . '</span>'; //    var_dump();
+}
+
+$notice = '';
+if (count($notices) > 0) {
+    $notice = '<p class="help-block">' . implode('<br />', $notices) . '</p>';
+}
+
+$class_label = '';
+$class = $this->getElement('required') ? 'form-is-required ' : '';
+$class_group = trim('radio-group form-group ' . $class . $this->getWarningClass());
+
+if (trim($this->getLabel()) != '') {
+    echo '<div class="'.$class_group.'">
+    <label class="control-label'.$class_label.'">'.$this->getLabel().'</label>';
+}
+
+foreach ($options as $key => $value) {
+    echo '<div class="radio';
+    echo (bool) $this->getElement('inline') ? '-inline' : '';
+    echo trim($this->getLabel()) == '' ? $this->getWarningClass() : '';
+    echo '">';
+
+    $attributes = [
+        'id' => $this->getFieldId() . '-' . htmlspecialchars($key),
+        'name' => $this->getFieldName(),
+        'value' => $key,
+        'type' => 'radio',
+    ];
+
+    if ($key == $this->getValue()) {
+        $attributes['checked'] = 'checked';
+    }
+
+    $attributes = $this->getAttributeElements($attributes);
+
+    echo '  <label>
+            <input '.implode(' ', $attributes).' />
+            '.$this->getLabelStyle($value).'
+        </label>
+    </div>';
+}
+
+echo $notice;
+
+if (trim($this->getLabel()) != '') {
+    echo '</div>';
+}

--- a/ytemplates/bootstrap/value.select.tpl.php
+++ b/ytemplates/bootstrap/value.select.tpl.php
@@ -1,0 +1,52 @@
+<?php
+
+$notice = [];
+if ($this->getElement('notice') != '') {
+    $notice[] = rex_i18n::translate($this->getElement('notice'), false);
+}
+if (isset($this->params['warning_messages'][$this->getId()]) && !$this->params['hide_field_warning_messages']) {
+    $notice[] = '<span class="text-warning">' . rex_i18n::translate($this->params['warning_messages'][$this->getId()], false) . '</span>'; //    var_dump();
+}
+if (count($notice) > 0) {
+    $notice = '<p class="help-block">' . implode('<br />', $notice) . '</p>';
+} else {
+    $notice = '';
+}
+
+$class = $this->getElement('required') ? 'form-is-required ' : '';
+$class_group = trim('form-group ' . $class . $this->getWarningClass());
+
+$class_label[] = 'control-label';
+
+$attributes = [];
+$attributes['class'] = 'form-control';
+$attributes['id'] = $this->getFieldId();
+if ($multiple) {
+    $attributes['name'] = $this->getFieldName() . '[]';
+    $attributes['multiple'] = 'multiple';
+} else {
+    $attributes['name'] = $this->getFieldName();
+}
+if ($size > 1) {
+    $attributes['size'] = $size;
+}
+
+$attributes = $this->getAttributeElements($attributes, ['autocomplete', 'pattern', 'required', 'disabled', 'readonly']);
+
+echo '
+<div class="'.$class_group.'" id="'.$this->getHTMLId().'">
+    <label class="'.implode(' ', $class_label).'" for="'.$this->getFieldId().'">'.$this->getLabel().'</label>
+    <select '.implode(' ', $attributes).'>';
+    foreach ($options as $key => $value):
+        echo '<option value="'.htmlspecialchars($key).'" ';
+        if (in_array((string) $key, $this->getValue(), true)) {
+            echo ' selected="selected"';
+        }
+        echo '>';
+        echo $this->getLabelStyle($value);
+        echo '</option>';
+        endforeach;
+echo '
+    </select>
+    ' . $notice . '
+</div>';


### PR DESCRIPTION
In älteren Projekten immer wieder im Einsatz - im Vergleich zum komplexen Choice-Feld eine einfache Alternative. Angepasst an YForm 4.