### PR TITLE
"Übernehmen" gedrückt: zuletzt aktiven Tab wieder aktivieren

### DIFF
--- a/lib/yform/value/tabs.php
+++ b/lib/yform/value/tabs.php
@@ -14,8 +14,11 @@
  *  - group-by: Clusterung als Tab-Gruppe
  *  - default:  Beim Anzeigen ausgewählter Default-Tab (1= Der erste / 2 = der ausgewählte)
  *
- * Wenn in einem Tab ein feld mit Fehlermeldung steckt, wird der Tab optisch markiert
+ * Wenn in einem Tab ein Feld mit Fehlermeldung steckt, wird der Tab optisch markiert
  * und aktiviert, unabhängig von den Einstellungen in "default".
+ * 
+ * Wurde das Formulat mit "Übernehmen" gespeichert wird der zuletzt aktive Tab wieder aktiv
+ * gesetzt. Ausnahme: in einem anderen Tab ist ein Feld mit Fehlermeldung. 
  */
 
 class rex_yform_value_tabs extends rex_yform_value_abstract

--- a/lib/yform/value/tabs.php
+++ b/lib/yform/value/tabs.php
@@ -59,9 +59,11 @@ class rex_yform_value_tabs extends rex_yform_value_abstract
         // Der letzte Tab (nur Platzhalter für den Abschluss der Tabgruppe) ist nie aktiv.
         $tabElements[array_key_last($tabElements)]->setElement('default', '1');
 
+        // Zuletzt aktivierten Tab zwecks Wiederaktivierung aus dem REQUEST holen
+        $active = rex_request::request(md5($this->getFieldName()),'int',-1);
+
         // In den Tabs die steuernden Informationen eintragen
         $i = 0;
-        $active = -1;
         foreach ($tabElements as $id => $tab) {
             $tab->tabset = $tabElements;
             $tab->sequence = $i++;
@@ -92,6 +94,7 @@ class rex_yform_value_tabs extends rex_yform_value_abstract
         if( $firstErrorTab < PHP_INT_MAX) {
             $active = $firstErrorTab;
         }
+        // den aktiven Tab als solchen markieren
         $tabElements[$active]->selected = true;
     }
 

--- a/ytemplates/bootstrap/value.tabs.tpl.php
+++ b/ytemplates/bootstrap/value.tabs.tpl.php
@@ -19,7 +19,9 @@
  * Platzhalter zum Schließen ohne eigenen Menüeintrag.
  */
 if ('open_tabset' === $option) {
-    echo '<ul class="nav nav-tabs">',PHP_EOL;
+    $activeId = $tabset[array_key_first($tabset)]->getId();
+    $uid = 'yff'.uniqid();
+    echo '<ul class="nav nav-tabs" id="',$uid,'-t">',PHP_EOL;
     foreach ($tabset as $tab) {
         if (PHP_INT_MAX !== $tab->sequence) {
             $tabLabel = $tab->getLabel();
@@ -27,16 +29,19 @@ if ('open_tabset' === $option) {
             $class = [];
             if ($tab->selected) {
                 $class[] = 'active';
+                $activeId = $tab->getId();
             }
             if ($tab->hasErrorField) {
                 $class[] = $tab->hasErrorField;
                 $tabLabel = '<span class="text-danger"><i class="fa fa-warning"></i> ' . $tabLabel . '</span>';
             }
             $class = $class ? ' class="'.implode(' ', $class).'"' : '';
-            echo '  <li role="presentation"',$class,'><a data-toggle="tab" href="#',$tabHTMLid,'">',$tabLabel,'</a></li>',PHP_EOL;
+            echo '  <li role="presentation"',$class,'><a data-toggle="tab" href="#',$tabHTMLid,'" data-field="',$tab->getId(),'">',$tabLabel,'</a></li>',PHP_EOL;
         }
     }
     echo '</ul>',PHP_EOL;
+    echo '<input type="hidden" name="',md5($this->getFieldName()),'" value="',$activeId,'" />';
+    echo '<script>$(\'#',$uid,'-t\').on("show.bs.tab",e=>{e.currentTarget.nextElementSibling.value=e.target.dataset.field;});</script>';
     echo '<div class="panel panel-default tab-content">',PHP_EOL;
 }
 


### PR DESCRIPTION
Wurde ein Formular nicht mit "Speichern" sondern "Übernehmen" gesichert, wird es wieder neu angezeigt. Dann würde (Fehlerfall ausgenommen, siehe PR #42) wieder der normalerweise aktive Tab angezeigt. 

Da "Übernehmen" hauptsächlich für Zwischenspeicherungen gedacht ist, sollte man auch an der Stelle weiterarbeiten können, an der man zuletzt war. Der PR sorgt daür, dass die Nummer des zum Zeitpunkt des Speicherns aktiven Tabs als Rückmeldung mit dem Formular verschickt wird. Der Wert wird dann priorisiert für den aktiven Tab benutzt, so dass der zuletzt aktive Tab auch bei der Wiederanzeige aktiv ist (außer im Fehlerfall). 