### PR TITLE
Lat/Lng um Bereichprüfung (Wert von bis) erweitert

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -64,3 +64,11 @@ yform_values_custom_url_ylink = YForm-Link-Widget (label_text::yform_tabelle::an
 yform_email_list_send_preview = Vorschau an Test-Adresse senden 
 yform_email_list_send_preview_success = Die Vorschau des E-Mail-Templates "%s" wurde an <b>%s</b> verschickt. 
 yform_email_list_send_preview_subject = Vorschau des E-Mail-Templates "%s"
+
+# YForm Lat-Field (Breitengrade)
+yform_values_numberlat_description = 🧩 YForm Field: Eingabefeld für einen <b>Breitengrad (-90°...90°)</b>
+yform_values_numberlat_range_error = {0}: der Wert muss im Bereich -90°...90° liegen.
+
+# YForm Lng-Field (Längengrade)
+yform_values_numberlng_description = 🧩 YForm Field: Eingabefeld für einen: <b>Längengrad (-180°...180°)</b>
+yform_values_numberlng_range_error = {0}: der Wert muss im Bereich -180°...180° liegen.

--- a/lib/yform/value/number_lat.php
+++ b/lib/yform/value/number_lat.php
@@ -2,11 +2,51 @@
 
 class rex_yform_value_number_lat extends rex_yform_value_number
 {
+
+    /**
+     * Nachdem ggf. auf das Feld gesetzte individuelle Validierungen durchgeführt
+     * wurden, erfolgt hier noch final die impliziete Validierung auf den Gültigkeits-
+     * bereich der Koordinate (-90.0° ... 90.0°).
+     *
+     * Überprüfungen z.B. auf
+     * - leere Felder
+     * - nicht numerische String-Eingaben
+     * - NULL
+     * müssen als individuelle Validierungen durchgeführt werden bzw. sind
+     * irgendwie in der Parent-Klasse realisiert.
+     *
+     * Wenn es bereits eine Fehlermeldung aus inidividuellen Validierungen gibt
+     * entfällt die Aktion. Gleiches gilt für Werte, die nicht numerisch sind
+     * (NULL, string).
+     */
+    public function postValidateAction(): void
+    {
+        parent::postValidateAction();
+
+        if (isset($this->params['warning'][$this->getId()])) {
+            return;
+        }
+
+        $value = $this->getValue() ?? '';
+        if ('' === trim($value) ) {
+            return;
+        }
+
+        $value = is_numeric($value) ? (float) $value : 999;
+        if ($value < -90.0 || $value > 90.0) {
+            $this->params['warning'][$this->getId()] = $this->params['error_class'];
+            $this->params['warning_messages'][$this->getId()] = rex_i18n::msg('yform_values_numberlat_range_error',$this->getLabel());
+        }
+    }
+
     public function getDescription(): string
     {
         return 'number_lat|name|label|precision|scale|defaultwert|[no_db]|[unit]|[notice]|[attributes]';
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function getDefinitions(): array
     {
         return [
@@ -31,7 +71,7 @@ class rex_yform_value_number_lat extends rex_yform_value_number
                 ['intfromto' => ['name' => 'precision', 'from' => '1', 'to' => '65', 'message' => rex_i18n::msg('yform_values_number_error_precision', '1', '65')]],
                 ['intfromto' => ['name' => 'scale', 'from' => '0', 'to' => '30', 'message' => rex_i18n::msg('yform_values_number_error_scale', '0', '30')]],
             ],
-            'description' => rex_i18n::msg('yform_values_number_description'),
+            'description' => rex_i18n::msg('yform_values_numberlat_description'),
             'db_type' => ['DECIMAL({precision},{scale})'],
             'hooks' => [
                 'preCreate' => static function (rex_yform_manager_field $field, $db_type) {


### PR DESCRIPTION
Ich hab mal die beiden Values **number_lat** und **number_lng** um eine impliziete Bereichs-Validierung ergänzt. Ja, könnte man auch expliziet durchführen, indem ein MinMax-Validator auf das fFld gelegt wird. Aber wozu würde man dann noch ein Lat bzw. Lng-Feld brauchen.

Die Validierung findet erst dann statt, wenn ggf. hinzugefügte Validatoren bereits durch sind (z.B. Prüfung ob leer) -> in `postValidateAction()`. Wenn es bereits eine fehlermeldung (aus vorhergehenden Validierungen) gibt oder wenn der Wert leer ist, wird abgebrochen. Ist der Wert jedoch numerisch, wird auf die Einhaltung der logischen Grenzen geprüft

- Latitude: -90 ... +90
- Longitude: -180 ... +180.
- 
<img width="803" alt="grafik" src="https://github.com/user-attachments/assets/d4099022-1803-423b-b20e-748e5f17bd6b" />

Bei der Gelegenheit habe ich die Feldbeschreibung angepasst an den Sinn und Zweck des Feldes. Vorher stand dort derselbe Text wie beim number-Feld ohne Hinweis, dass es ein Yform-Field-Addon-Feld ist.
 
<img width="602" alt="grafik" src="https://github.com/user-attachments/assets/403edcd0-a7af-4340-95f7-a5345245cc6a" />

Außerdem mit RexStan überprüft (Level 6). 
