### PR TITLE
YForm Feld-Verwaltung: Limit auf 200 hochpatchen

### DIFF
--- a/install.php
+++ b/install.php
@@ -33,3 +33,4 @@ if (null == rex_config::get('yform_field', 'choice_status_secret')) {
 }
 
 include(__DIR__ .'/install/yform_choice_patch.php');
+include(__DIR__ .'/install/yform_field_list_patch.php');

--- a/install/yform_field_list_patch.php
+++ b/install/yform_field_list_patch.php
@@ -1,0 +1,20 @@
+<?php
+
+$addon = rex_addon::get('yform');
+
+// In YForm 5 bereits auf 200 gestellt, daher kann man das hier relativ gefahrlos patchen.
+
+if (version_compare($addon->getVersion(), '5.0.0', '<')) {
+    $file = rex_path::addon('yform', 'lib/manager/manager.php');
+    $content = rex_file::get($file);
+
+    if (strpos($content, 'rex_list::factory($sql, rowsPerPage: 200, defaultSort: [') === false) {
+        $content = preg_replace(
+            '/rex_list::factory\(\$sql,\s*defaultSort:/',
+            'rex_list::factory($sql, rowsPerPage: 200, defaultSort:',
+            $content,
+            1
+        );
+        rex_file::put($file, $content);
+    }
+}


### PR DESCRIPTION
Kommt in YForm Version 5.0 - das dauert mir zu lange.

https://github.com/yakamara/yform/blob/bb3d1d9155f65f197be6eb2a20d0d23ccbb6b7d9/lib/manager/manager.php#L1342-L1344